### PR TITLE
Update to overwrite documents in `registry` index by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,12 +290,6 @@
       <version>${solr.version}</version>
       <type>jar</type>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <artifactId>solr-solrj</artifactId>
@@ -304,11 +298,6 @@
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
-  	<dependency>
-  	    <groupId>org.slf4j</groupId>
-  	    <artifactId>slf4j-jdk14</artifactId>
-  	    <version>2.0.12</version>
-  	</dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/src/main/java/gov/nasa/pds/harvest/search/ingest/SearchIngester.java
+++ b/src/main/java/gov/nasa/pds/harvest/search/ingest/SearchIngester.java
@@ -3,20 +3,15 @@ package gov.nasa.pds.harvest.search.ingest;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
-
 import java.util.logging.Logger;
-
 import gov.nasa.jpl.oodt.cas.filemgr.ingest.Ingester;
 import gov.nasa.jpl.oodt.cas.filemgr.structs.exceptions.CatalogException;
 import gov.nasa.jpl.oodt.cas.filemgr.structs.exceptions.IngestException;
 import gov.nasa.jpl.oodt.cas.metadata.MetExtractor;
 import gov.nasa.jpl.oodt.cas.metadata.Metadata;
 import gov.nasa.pds.harvest.search.constants.Constants;
-
 import gov.nasa.pds.harvest.search.logging.ToolsLevel;
 import gov.nasa.pds.harvest.search.logging.ToolsLogRecord;
-import gov.nasa.pds.harvest.search.registry.FileData;
-import gov.nasa.pds.harvest.search.registry.FileDataLoader;
 import gov.nasa.pds.harvest.search.registry.MetadataExtractor;
 import gov.nasa.pds.harvest.search.registry.RegistryDAO;
 import gov.nasa.pds.harvest.search.registry.RegistryMetadata;
@@ -116,42 +111,16 @@ public class SearchIngester implements Ingester
 				
 		try 
 		{
-			if(!hasProduct(searchUrl, lid, vid)) 
-			{
-			    RegistryMetadata registryMeta = metaExtractor.extract(prodFile.getAbsolutePath());
+          RegistryMetadata registryMeta = metaExtractor.extract(prodFile.getAbsolutePath());
 			    
-			    // Save product file
-			    registryDAO.saveProduct(registryMeta, prodFile);
-			    
-				log.log(new ToolsLogRecord(ToolsLevel.SUCCESS, "Successfully registered product: " + lidvid, prodFile));
-				++HarvestSolrStats.numProductsRegistered;
-		
-				// Save XPaths
-				/*
-				try
-				{
-					XPathDAO.postXPaths(prodFile, lid, vid);
-		            log.log(new ToolsLogRecord(ToolsLevel.SUCCESS,
-		                    "Successfully posted document of XPaths of entire label to the xpath Solr collection", prodFile));
-					++HarvestSolrStats.numXPathDocsRegistered;
-				} 
-				catch (Exception e) 
-				{
-					log.log(new ToolsLogRecord(ToolsLevel.INFO,
-							"Error posting to xpath Solr Collection endpoint: " + e.getMessage()));
-					++HarvestSolrStats.numXPathDocsNotRegistered;
-				}
-				*/
-				
-				return lidvid;
-			} 
-			else 
-			{
-				++HarvestSolrStats.numProductsNotRegistered;
-				String message = "Product already exists: " + lidvid;
-				log.log(new ToolsLogRecord(ToolsLevel.WARNING, message, prodFile));
-				return null;
-			}
+          // Save product file
+          registryDAO.saveProduct(registryMeta, prodFile);
+
+          log.log(new ToolsLogRecord(ToolsLevel.SUCCESS,
+              "Successfully registered product: " + lidvid, prodFile));
+          ++HarvestSolrStats.numProductsRegistered;
+
+          return lidvid;
 		} 
 		catch(CatalogException c)
 		{

--- a/src/main/java/gov/nasa/pds/harvest/search/logging/formatter/HarvestFormatter.java
+++ b/src/main/java/gov/nasa/pds/harvest/search/logging/formatter/HarvestFormatter.java
@@ -5,7 +5,6 @@ import java.util.Map.Entry;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
-
 import gov.nasa.pds.harvest.search.logging.ToolsLevel;
 import gov.nasa.pds.harvest.search.logging.ToolsLogRecord;
 import gov.nasa.pds.harvest.search.stats.HarvestSolrStats;
@@ -74,37 +73,29 @@ public class HarvestFormatter extends Formatter {
   private void processSummary() 
   {
     int totalFiles = HarvestSolrStats.numGoodFiles + HarvestSolrStats.numBadFiles;
-    int totalProducts = HarvestSolrStats.numProductsRegistered + HarvestSolrStats.numProductsNotRegistered;    
-    int totalDocuments = HarvestSolrStats.numDocumentsCreated + HarvestSolrStats.numDocumentsNotCreated;
 
     summary.append(HarvestSolrStats.numGoodFiles + " of " + totalFiles
         + " file(s) processed, " + HarvestSolrStats.numFilesSkipped
         + " other file(s) skipped" + lineFeed);
     summary.append(numErrors + " error(s), " + numWarnings + " warning(s)"
         + doubleLineFeed);
-    
+
+
     // Registry collection (Labels)
     summary.append("Product Labels:" + lineFeed);
-    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numProductsRegistered, "Successfully registered"));
+    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numProductsRegistered,
+        "Successfully registered"));
     summary.append(lineFeed);
-    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numProductsNotRegistered, "Failed to register"));
+    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numProductsNotRegistered,
+        "Failed to register"));
     summary.append(doubleLineFeed);
     
-    // Search collection
-    summary.append("Search Service Solr Documents:" + lineFeed);
+    // Registry Search collection
+    summary.append("Registry Search Solr Documents:" + lineFeed);
     summary.append(String.format("%-10d %-25s", HarvestSolrStats.numDocumentsCreated, "Successfully created"));
     summary.append(lineFeed);
     summary.append(String.format("%-10d %-25s", HarvestSolrStats.numDocumentsNotCreated, "Failed to get created"));
     summary.append(doubleLineFeed);
-    
-    // XPath
-    /*
-    summary.append("XPath Solr Documents (Quick Look Only, Ignore Failed Ingestions):" + lineFeed);
-    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numXPathDocsRegistered, "Successfully registered"));
-    summary.append(lineFeed);
-    summary.append(String.format("%-10d %-25s", HarvestSolrStats.numXPathDocsNotRegistered, "Failed to register"));
-    summary.append(doubleLineFeed);
-    */
     
     summary.append("Product Types Handled:" + lineFeed);
     for (Entry<String, BigInteger> entry :

--- a/src/main/java/gov/nasa/pds/harvest/search/registry/RegistryDAO.java
+++ b/src/main/java/gov/nasa/pds/harvest/search/registry/RegistryDAO.java
@@ -1,13 +1,11 @@
 package gov.nasa.pds.harvest.search.registry;
 
 import java.io.File;
-
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
-
 import gov.nasa.pds.harvest.search.util.SolrManager;
 import gov.nasa.pds.harvest.search.util.TransactionManager;
 


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Update default functionality for `registry` index to overwrite

## ⚙️ Test Data and/or Report
Re-ran harvest on a test data set for a second time:
```
Summary:

14 of 14 file(s) processed, 0 other file(s) skipped
0 error(s), 0 warning(s)

Product Labels:
14         Successfully registered
0          Failed to register

Registry Search Solr Documents:
14         Successfully created
0          Failed to get created

Product Types Handled:
6 Product_Collection
7 Product_Context
1 Product_Bundle


Registry Package Id: cf66aef3-dc75-43a1-b764-1bc4eb0983c7
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Resolves #66
