### PR TITLE
Upgrade Apache Solr to 9.10.1 to address security vulnerabilities

### DIFF
--- a/catalog-legacy/pom.xml
+++ b/catalog-legacy/pom.xml
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>9.10.0</version>
+      <version>9.10.1</version>
     </dependency>
     
 	<dependency>

--- a/harvest-legacy/pom.xml
+++ b/harvest-legacy/pom.xml
@@ -222,20 +222,20 @@
     <dependency>
       <artifactId>solr-core</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.10.0</version>
+      <version>9.10.1</version>
       <type>jar</type>
       <scope>compile</scope>
       <exclusions>
 		<exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-api</artifactId>
-        </exclusion>        
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <artifactId>solr-solrj</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.10.0</version>
+      <version>9.10.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/registry-mgr-legacy/pom.xml
+++ b/registry-mgr-legacy/pom.xml
@@ -114,14 +114,14 @@
     <dependency>
       <artifactId>solr-core</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.10.0</version>
+      <version>9.10.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <artifactId>solr-solrj</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.10.0</version>
+      <version>9.10.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/registry-mgr-legacy/src/main/resources/build/Dockerfile
+++ b/registry-mgr-legacy/src/main/resources/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:9.10.0
+FROM solr:9.10.1
 ADD VERSION.txt .
 
 # Config sets


### PR DESCRIPTION
## 🗒️ Summary

Upgrades all Apache Solr dependencies from `9.10.0` → `9.10.1` across all modules to address potential security vulnerabilities identified by Dependabot.

**Files changed:**
- `harvest-legacy/pom.xml` — `solr-core` + `solr-solrj`
- `registry-mgr-legacy/pom.xml` — `solr-core` + `solr-solrj`
- `catalog-legacy/pom.xml` — `solr-solrj`
- `registry-mgr-legacy/src/main/resources/build/Dockerfile` — base image `FROM solr:9.10.0` → `FROM solr:9.10.1`

> 🤖 This PR was generated with assistance from Claude (AI). Approximately 80% of the changes were AI-influenced (version string updates across 4 files).

## ⚙️ Test Data and/or Report

`mvn install` run successfully against all 5 modules with no new errors or failures:

```
Legacy Registry .................................... SUCCESS [  0.057 s]
Legacy Search Core ................................. SUCCESS [  1.052 s]
Legacy Harvest Tool ................................ SUCCESS [ 13.525 s]
Legacy Catalog Tool ................................ SUCCESS [  1.637 s]
Legacy Registry Manager Solr ....................... SUCCESS [  0.919 s]
BUILD SUCCESS
```

## ♻️ Related Issues

Resolves #249

## 🤓 Reviewer Checklist

- [ ] Documentation updated (if applicable)
- [ ] No sensitive information included
- [ ] Tests pass
- [ ] Breaking changes documented (N/A — patch version bump only)