### PR TITLE
Fix CVE-2025-48924, CVE-2025-46392, CVE-2026-25645 security vulnerabilities

### DIFF
--- a/catalog-legacy/pom.xml
+++ b/catalog-legacy/pom.xml
@@ -168,9 +168,9 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
       <scope>compile</scope>
     </dependency>
 
@@ -195,9 +195,9 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-      <version>1.10</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/catalog-legacy/src/main/java/gov/nasa/pds/citool/CITool.java
+++ b/catalog-legacy/src/main/java/gov/nasa/pds/citool/CITool.java
@@ -15,8 +15,7 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.configuration.AbstractConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
@@ -285,7 +284,6 @@ public class CITool
     public void query(File configuration) throws ConfigurationException {
         try {
             ToolsPropertiesConfiguration config = null;
-            AbstractConfiguration.setDefaultListDelimiter(',');
             config = new ToolsPropertiesConfiguration(configuration);
             if (config.isEmpty()) {
                 throw new ConfigurationException(

--- a/catalog-legacy/src/main/java/gov/nasa/pds/citool/commandline/options/ToolsPropertiesConfiguration.java
+++ b/catalog-legacy/src/main/java/gov/nasa/pds/citool/commandline/options/ToolsPropertiesConfiguration.java
@@ -2,12 +2,16 @@ package gov.nasa.pds.citool.commandline.options;
 
 import java.io.File;
 import java.util.List;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 
 public class ToolsPropertiesConfiguration extends PropertiesConfiguration {
     public ToolsPropertiesConfiguration(File file) throws ConfigurationException {
-        super(file);
+        super();
+        setListDelimiterHandler(new DefaultListDelimiterHandler(','));
+        new FileHandler(this).load(file);
     }
 
     public boolean containsKey(ConfigKey configKey) {

--- a/catalog-legacy/src/main/java/gov/nasa/pds/citool/search/DocWriter.java
+++ b/catalog-legacy/src/main/java/gov/nasa/pds/citool/search/DocWriter.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 public class DocWriter 
 {
@@ -40,7 +40,7 @@ public class DocWriter
 			for(String value: field.getValue())
 			{
 				writer.write("<field name=\"" + fieldName + "\">");
-				StringEscapeUtils.escapeXml(writer, value);
+				writer.write(StringEscapeUtils.escapeXml10(value));
 				writer.write("</field>\n");
 			}
 		}

--- a/src/main/resources/requirements.txt
+++ b/src/main/resources/requirements.txt
@@ -1,4 +1,4 @@
 lxml~=4.9.0
-requests~=2.32.0
+requests~=2.33.0
 pds.solr-to-es~=0.3.0
 pandas~=2.2.2


### PR DESCRIPTION
## 🗒️ Summary

Addresses three CVE security vulnerabilities in `catalog-legacy` and Python dependencies:

| CVE | Package | Fix |
|-----|---------|-----|
| CVE-2025-48924 | `commons-lang:commons-lang:2.6` | Migrated to `org.apache.commons:commons-lang3:3.18.0` |
| CVE-2025-46392 | `commons-configuration:commons-configuration:1.10` | Migrated to `org.apache.commons:commons-configuration2:2.11.0` |
| CVE-2026-25645 | `requests~=2.32.0` (pip) | Bumped to `requests~=2.33.0` |

**API migration notes (non-trivial changes):**
- `commons-lang3`: `StringEscapeUtils.escapeXml(Writer, String)` → `writer.write(StringEscapeUtils.escapeXml10(String))`
- `commons-configuration2`: `PropertiesConfiguration(File)` constructor removed → load via `FileHandler`; `AbstractConfiguration.setDefaultListDelimiter()` static global → `DefaultListDelimiterHandler` set per-instance

> 🤖 Triaged and implemented with assistance from Claude — estimated ~90% AI-influenced

## ⚙️ Test Report

Full smoke test suite run locally with Docker (Solr 9.10.1):
- ✅ **PDS4**: Harvest generated 86 docs → 82 verified in Solr
- ✅ **PDS3**: Catalog tool generated 157 docs → 217 verified in Solr

## ♻️ Related Issues

Closes NASA-PDS/outlaw-tracker#24
Closes NASA-PDS/outlaw-tracker#25
Closes NASA-PDS/outlaw-tracker#22

## 🤓 Reviewer Checklist

- [ ] Are there new requirements this work affects?
- [ ] Have all security vulnerabilities been addressed?
- [ ] Are automated tests adequate for the changes?
- [ ] Is the documentation up to date?